### PR TITLE
Feature: Update `Codecov` Github action to be optional

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,6 @@
 {
     "project_name": "go-template",
     "module_root": "github.com/notsatan",
-    "module_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
+    "module_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+    "use_codecov": "y"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,6 +1,6 @@
 ### Simply create the `tmp`, `bin` and `coverage` directories
 
-from os import mkdir
+from os import mkdir, remove
 from os.path import join
 from pathlib import Path
 from sys import exit
@@ -18,6 +18,18 @@ temp_directories: List[str] = [
 ]
 
 
+def remove_codecov():
+    """
+    Removes `codecov.yml` file from the project root if Codecov is not being used
+    """
+
+    codecov_needed: bool = bool("{{ cookiecutter.use_codecov }}".lower() == "y")
+
+    if not codecov_needed:
+        # If Codecov is not needed, delete `codecov.yml`
+        remove("codecov.yml")
+
+
 def create_temp_directories():
     """
     Creates an empty directory for `directories`, places a gitignore file inside them
@@ -33,6 +45,7 @@ def create_temp_directories():
 
 runners: Callable[[], None] = [
     create_temp_directories,
+    remove_codecov,
 ]
 
 for runner in runners:

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -2,20 +2,20 @@ from re import match
 from sys import exit
 from typing import Callable
 
-# Regex to determine if a module name is valid. Conditions to pass;
-#   - First letter should be lower case alphabet
-#   - Should consist of alphabets and/or hyphen ONLY
-#   - Should have length between [3, 11] characters (inclusive)
-MODULE_NAME_REGEX: str = r"^[a-z][a-zA-Z\-]{2,10}$"
-
-# Name of the module from Cookiecutter configs
-module_name = r"{{ cookiecutter.module_name }}"
-
 
 def validate_module_name():
     """
     Raises `ValueError` if module name is invalid. Uses `MODULE_NAME_REGEX` to validate
     """
+
+    # Regex to determine if a module name is valid. Conditions to pass;
+    #   - First letter should be lower case alphabet
+    #   - Should consist of alphabets and/or hyphen ONLY
+    #   - Should have length between [3, 11] characters (inclusive)
+    MODULE_NAME_REGEX: str = r"^[a-z][a-zA-Z\-]{2,10}$"
+
+    # Name of the module from Cookiecutter configs
+    module_name = r"{{ cookiecutter.module_name }}"
 
     if not match(MODULE_NAME_REGEX, module_name):
         raise ValueError(f"Error: Invalid module name: `{module_name}`")

--- a/{{cookiecutter.project_name}}/.github/workflows/testing.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/testing.yml
@@ -39,7 +39,11 @@ jobs:
 
       - name: Test
         run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic -gcflags=-l
+{% endraw %}
 
+{%- if cookiecutter.use_codecov.lower() == 'y' -%}
+{% raw %}
+      # Generate a Codecov report
       - name: Upload coverage report
         uses: codecov/codecov-action@v1
         with:
@@ -51,3 +55,4 @@ jobs:
           path_to_write_report: ./coverage/codecov_report.gz
           verbose: true
 {% endraw %}
+{% endif %}

--- a/{{cookiecutter.project_name}}/codecov.yml
+++ b/{{cookiecutter.project_name}}/codecov.yml
@@ -1,19 +1,24 @@
 codecov:
+  # CI Pipeline fails if code-coverage does not meet standards
   require_ci_to_pass: yes
 
 coverage:
   precision: 2
   round: down
-  range: "10...100"
+  range: "75...90"   # code coverage between 75-90% would be okay
   status:
     project:
+      # Comparisions made against base of PR, or parent commit
       default:
-        threshold: 10%
-        target: 50%
+        threshold: 20%  # Coverage can drop by at most 20% and still pass
+        target: 70%     # Coverage below 70% is a fail
+    
     patch:
+      # Measures lines modified in an individual commit/PR
       default:
-        threshold: 10%
-        target: 10% # Change this value after the initial release
+        threshold: 30%
+        target: 70%
+
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
Add a field `cookiecutter.use_codecov` that takes in a *yes*/*no* as input - indicating whether the user wants to include the Codecov Github action to generate test coverage reports with every CI cycle.

If the user decided not to use Codecov, the action would be removed from Github workflows, and the template will delete the `codecov.yml` file during the post-setup processing.

Note: Any input other than a "*y*" (case-insensitive) for `*cookiecutter.use_codecov*` would be taken as a "*no*"