### PR TITLE
Feature: Add test modes

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -34,12 +34,13 @@ help: Makefile
 	@sed -n 's/^[ \t]*##//p' $< | column -t -s ':' |  sed -e 's/^//'
 	@echo
 
-
 .PHONY: local-setup
 ## `local-setup`: Setup development environment locally
 local-setup:
+	@echo "  >  Ensuring directory is a git repository"
+	git init &> /dev/null
 	@echo "  >  Installing pre-commit"
-	pip install pre-commit
+	pip install pre-commit &> /dev/null
 	pre-commit install
 	@echo "  >  Installing GolangCI-Lint"
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
@@ -60,7 +61,6 @@ codestyle:
 	@echo -e "\n\t> Running Golang CI Lint"
 	@golangci-lint run --fix
 
-
 .PHONY: checkstyle
 ## `checkstyle`: Run linter(s) and check code-style
 checkstyle:
@@ -68,16 +68,40 @@ checkstyle:
 	@golangci-lint run
 
 
-.PHONY: test
-## :
-## `test`: Run tests and generate coverage report
-test:
+# Delibrately not revealing this command - designed to be consumed internally
+.PHONY: --test-runner
+--test-runner:
 	@go test ./... -race -covermode=atomic -coverprofile=./coverage/coverage.txt -gcflags=-l
 	@go tool cover -html=./coverage/coverage.txt -o ./coverage/coverage.html
 
+.PHONY: test
+## :
+## `test`: Run fast and medium tests
+test: export FAST_TEST="true"
+test: export MEDIUM_TEST="true"
+test: --test-runner
+
+.PHONY: fast-test
+## `fast-test`: Selectively run fast tests
+fast-test: export FAST_TEST="true"
+fast-test: --test-runner
+
+.PHONY: medium-test
+## `medium-test`: Selectively run medium tests
+medium-test: export MEDIUM_TEST="true"
+medium-test: --test-runner
+
+.PHONY: slow-test
+## `slow-test`: Selectively run long tests
+slow-test: export SLOW_TEST="true"
+slow-test: --test-runner
+
 
 .PHONY: test-suite
-## `test-suite`: Check-styles and run tests with a single command
+## `test-suite`: Checkstyle and run ALL tests
+test-suite: export FAST_TEST="true"
+test-suite: export MEDIUM_TEST="true"
+test-suite: export SLOW_TEST="true"
 test-suite: checkstyle test
 
 
@@ -103,6 +127,7 @@ docker-gen:
 clean-docker:
 	@echo Removing docker $(IMAGE):$(VERSION) ...
 	@docker rmi -f $(IMAGE):$(VERSION)
+
 
 ## :
 ##  NOTE: All docker-related commands can contain `IMAGE`


### PR DESCRIPTION
Add test modes - `fast`, `medium` and `slow`. Each of these modes sets an environment variable, the presence (or absence) of this environment variable can be used to control which tests are being run. This makes way for users (read programmers) to have a greater degree of control over which parts of the test suite are to be run

This branch also introduces grouped commands - `test` and `test-suite` - the former runs `fast` and `medium` tests, while the
latter runs the entire test suite along with the linter

Additional minor changes made to the makefile - redirect the output of smaller commands to /dev/null, ensuring that the console does not get littered with the output of minor commands