### PR TITLE
Feature: Rewrite `.golangci.yml` from scratch

### DIFF
--- a/{{cookiecutter.project_name}}/.golangci.yml
+++ b/{{cookiecutter.project_name}}/.golangci.yml
@@ -476,7 +476,6 @@ linters:
     - errorlint
     - exhaustive
     - forbidigo
-    - gochecknoinits
     - gci
     - gocognit
     - goconst
@@ -515,17 +514,8 @@ linters:
   # Interesting linters - enable if they fit your needs
   # - bodyclose
   # - godot
+  # - gochecknoinits
   # - godox
   # - nlreturn
   # - paralleltest
   # - tparallel
-
-
-  # don't enable:
-  # - asciicheck
-  # - gochecknoglobals
-  # - gocognit
-  # - goerr113
-  # - prealloc
-  # - testpackage
-  # - wsl


### PR DESCRIPTION
This branch introduces a complete rewrite of the `.golangci.yml` file present in the project root directory.

## Linters Added
 - `Cyclop`: Checks function and package cyclomatic complexity
 - `ErrName`: Ensures sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
 - `ErrorLint`: ErrorLint helps find code that will cause problems with the error wrapping scheme introduced in Go 1.13
 - `Forbidigo`: Forbids identifiers - currently, fails if code contains `print` statement. Can be further configured as needed
 - `Gocognit`: Computes and checks the cognitive complexity of functions, fails beyond the set limit of complexity
 - `GoFumpt`: Gofumpt checks whether code was [gofumpt](https://github.com/mvdan/gofumpt)-ed
 - `FunLen`: Throws an error if a function exceeds the configured length, or has a greater number of statements than set
 - `MakeZero:`: Finds slice declarations with a non-zero initial length, that is then being used in an append statement
 - `NestIf`: Reports error for deeply nested if statements
 - `NilErr`: Reports an issue for code that returns nil even when there is no error
 - `NilNil`: Ensures if a function is returning `nil` error, it won't be returning a nil object as well
 - `PreDeclared`: Locate code that shadows one of Go's predeclared identifiers
 - `Revive`: A simple linter. Drop-in replacement for `golint`
 - `Tagliatelle`: Checks struct tags
 - `Tenv`: Ensures `os.Setenv` is being used for tests since Go 1.17 instead of `t.Setenv`
 - `THelper`: Detects Go test helper methods without `t.Helper()` call and checks the consistency of test helpers
 - `WastedAssign`: Locates and throws an error for wasted assignment statements
 - `WrapCheck`: Checks that errors returned from external packages are wrapped

## Linters Removed
 - `BodyClose`: Specific to `net/http` package - won't be needed by default.
 - `GoLint`: Deprecated. The project repository has been archived
 - `GoCheckNoInits`: Very opinionated on the topic of "not using init functions". Not everyone wants to follow this, disabling it by default
 - `RowsErrCheck`: Specific to SQL queries. Same as `BodyClose`, won't be needed by default

---

Some of these linters may need their values to be tweaked for normal usage. Additionally, added a section of interesting linters - these are linters that are either very opinionated on a topic or very specific - such as the `BodyClose` linter being specific to just a single package. 

Additionally, this PR removes sections of the original `.golangci.yml` related to the GolangCI service (which has been taken down now).