### PR TITLE
Feature: Add `dependabot` config file

### DIFF
--- a/{{cookiecutter.project_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_name}}/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+
+    # Auto assign PRs raised to this account on Github
+    assignees:
+      - "{{ cookiecutter.go_module_path.split('/')[1] }}"
+
+    reviewers:
+      - "{{ cookiecutter.go_module_path.split('/')[1] }}"
+
+    # Labels to add to PRs raised
+    labels:
+      - "enhancement"
+
+    # Check for updates to dependencies once a week - Saturday
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Add a dependabot config file to template base - ensures that the generated templates would be able to use dependabot to fetch updates for external dependencies