### PR TITLE
BugFix: Patch bugs

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 
 from pathlib import Path
@@ -14,6 +15,24 @@ temp_directories: List[str] = [
     "bin",
     "coverage",
 ]
+
+
+def lincese_generator():
+    """
+    Generates the appropriate license for the template from the given options
+    """
+
+    # Get the selected license - the license file to be used will be the capitalized version
+    # of the first word in the license name
+    selected_license: str = "{{ cookiecutter.license }}"
+    license_file: str = re.findall(r"^[a-zA-Z]+", selected_license)[0]
+
+    source = os.path.join(CUR_DIR, "_licenses", license_file)
+    destination = os.path.join(CUR_DIR, "LICENSE")
+
+    # Move the selected license file, remove the `_licenses` directory when done
+    shutil.move(source, destination)
+    shutil.rmtree(os.path.join(CUR_DIR, "_licenses"), ignore_errors=True)
 
 
 def create_temp_directories():
@@ -87,24 +106,6 @@ def remove_precommit():
         os.remove(workflow)
 
 
-def lincese_generator():
-    """
-    Generates the appropriate license for the template from the given options
-    """
-
-    # Get the selected license - the license file to be used will be the capitalized version
-    # of the first word in the license name
-    selected_license: str = "{{ cookiecutter.license }}"
-    license_file: str = selected_license.split()[0].upper()
-
-    source = os.path.join(CUR_DIR, "_licenses", license_file)
-    destination = os.path.join(CUR_DIR, "LICENSE")
-
-    # Move the selected license file, remove the `_licenses` directory when done
-    shutil.move(source, destination)
-    shutil.rmtree(os.path.join(CUR_DIR, "_licenses"), ignore_errors=True)
-
-
 def remove_security_md():
     """
     Removes the `SECURITY.md` file in case the email field is empty -- if the email ID is empty,
@@ -120,11 +121,11 @@ def remove_security_md():
 
 
 runners: Callable[[Optional[Any]], None] = [
+    lincese_generator,
     create_temp_directories,
     remove_codecov,
     remove_workflows,
     remove_precommit,
-    lincese_generator,
     remove_security_md,
 ]
 


### PR DESCRIPTION
This branch addresses the few bugs and design changes that were lingering for some time now.

Switch to using complete import paths instead of selective imports from modules - this frees up the namespace, allowing variables to use names that were unavailable because of an imported function. Tested out all the changes made in the corresponding commit - nothing is broken (*yet*)

Patch a bug that caused `codecov.yml` file to remain even if the user opted to not use Codecov in the generated project. The cause for this was that the post-gen hook attempted to delete a file named `.codecov.yml` instead.

Patch bug causing the pre-commit configurations to remain even if a user didn't want it. While the post-gen hook responsible for removing the pre-commit configuration file worked by itself, it wasn't being called with the rest of the runner (most likely because I forgot to add the function to the list of runners in the post-gen hook).

Patch bug causing crash when `BSD` license template was used - the post-gen hook assumed that the first word of the chosen option would be the name of the license template file to be used. While this was true - it was so just for purely alphabetical words.

Fix this issue by switching to a regex pattern, extracting just the alphabetical word from the input