### PR TITLE
Feature: Allow excluding all Github-specific features

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,17 +5,17 @@
     "contact_email": "",
     "project_license_name": "{{ cookiecutter.project_name }}",
     "project_description": "go-template creates a customized Go project template to use as a base for your next project",
+    "github_specific_features": "y",
+    "use_codecov": "y",
+    "use_precommit": "y",
+    "go_version": [
+        "1.17",
+        "1.16"
+    ],
     "license": [
         "MIT",
         "BSD-3",
         "GNU GPL v3.0",
         "Apache Software License 2.0"
-    ],
-    "use_codecov": "y",
-    "use_precommit": "y",
-    "use_github_actions": "y",
-    "go_version": [
-        "1.17",
-        "1.16"
     ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -68,22 +68,28 @@ def remove_codecov(*, force: bool = False):
     return False
 
 
-def remove_workflows(*, force: bool = False):
+def disable_github_features(*, force: bool = False):
     """
-    Removes the `.github` directory containing Github workflows from project root if not needed
+    Removes the `.github` directory containing Github workflows from project root if not needed.
+    Additionally, goes on to remove any other file/directory that would be specific to Github
     """
 
-    actions_needed: bool = bool("{{ cookiecutter.use_github_actions }}".lower() == "y")
+    github_features_needed: bool = bool(
+        "{{ cookiecutter.github_specific_features }}".lower() == "y"
+    )
 
-    if not actions_needed or force:
-        dest_path: str = os.path.join(CUR_DIR, ".github")
-        if not os.path.exists(dest_path):
-            return False  # The directory to delete does not exist
+    if github_features_needed and not force:
+        # If Github-specific features are needed, and the action is not forced, skip
+        return
 
-        shutil.rmtree(dest_path, ignore_errors=True)
+    dest_path: str = os.path.join(CUR_DIR, ".github")
+    if not os.path.exists(dest_path):
+        return False  # The directory to delete does not exist
 
-        # Since workflows are to be removed, remove `codecov.yml` as well
-        remove_codecov(force=True)
+    shutil.rmtree(dest_path, ignore_errors=True)
+
+    # Since workflows are to be removed, remove `codecov.yml` as well
+    remove_codecov(force=True)
 
 
 def remove_precommit():
@@ -133,7 +139,7 @@ runners: Callable[[Optional[Any]], None] = [
     lincese_generator,
     create_temp_directories,
     remove_codecov,
-    remove_workflows,
+    disable_github_features,
     remove_precommit,
     check_email_provided,
 ]


### PR DESCRIPTION
This pull request allows users to decide if they want Github-specific features to be a part of the generated template! Not everyone uses Github, as such, forcing Github specific features on to someone who does not plan to use Github would be wrong

Currently, if a user chooses not to use Github-specific features - the Github configs such as workflows, issue and pull request templates, etc will be removed by removing the `.github` file.