### PR TITLE
Fix: Patch bug in module path causing crashes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "go-template",
     "go_module_path": "github.com/notsatan/go-template",
-    "license_owner": "{{ cookiecutter.go_module_path.split('/')[1] }}",
+    "license_owner": "notsatan",
     "contact_email": "",
     "project_description": "go-template creates a customized Go project template to use as a base for your next project",
     "github_specific_features": "y",

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,48 @@
+import re
+
+from sys import exit
+from typing import Callable, List, Any, Optional
+
+
+def is_module_hosted_on_github():
+    """
+    Ensures if user has chosen to enable github-specific features, the module path
+    should belong to Github
+    """
+
+    # Regex pattern to validate module name - might need some tweaks
+    pattern = r"^github.com\/\w+\\w+\/?$"
+
+    # If the user has not opted for Github-specific features, skip
+    perform_check: bool = bool(
+        "{{ cookiecutter.github_specific_features }}".lower() == "y"
+    )
+
+    if not perform_check:
+        return
+
+    if not re.match(pattern, "{{ cookiecutter.go_module_path }}"):
+        raise ValueError(
+            "Attempt to enable Github-specific features when module path does not "
+            + "belong to github"
+        )
+
+
+validators: Callable[[Optional[Any]], None] = [
+    is_module_hosted_on_github,
+]
+
+for validator in validators:
+    try:
+        validator()
+    except Exception as e:
+        print(f"\n\nRan into exception while running validator: `{validator.__name__}`")
+        print(f"Stacktrace: `{type(e).__name__}: {e}`")
+        print(
+            f"""  \
+\n\ngo-template is still under development, if you feel that the error is incorrect, \
+you are encouraged to raise an issue at: \n\thttps://github.com/notsatan/go-template
+"""
+        )
+
+        exit(-10)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -11,7 +11,7 @@ def is_module_hosted_on_github():
     """
 
     # Regex pattern to validate module name - might need some tweaks
-    pattern = r"^github.com\/\w+\\w+\/?$"
+    pattern = r"^github.com\/[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-]+\/?$"
 
     # If the user has not opted for Github-specific features, skip
     perform_check: bool = bool(

--- a/{{cookiecutter.project_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_name}}/.github/dependabot.yml
@@ -1,3 +1,4 @@
+{%- if cookiecutter.github_specific_features.lower() == 'y' -%}
 version: 2
 updates:
   - package-ecosystem: "gomod"
@@ -17,4 +18,4 @@ updates:
     # Check for updates to dependencies once a week - Saturday
     schedule:
       interval: "weekly"
-      day: "saturday"
+      day: "saturday"{% endif %}


### PR DESCRIPTION
## The Issue

If a non-Github path is being used as the value for the `go_module_path` field, it would lead to a crash with the following error message

```sh
Unable to render variable 'license_owner'
Error message: list object has no element 1
Context: {
    "cookiecutter": {
        "contact_email": "",
        "github_specific_features": "y",
        "go_module_path": "github.com/notsatan/go-template",
        "go_version": [
            "1.17",
            "1.16"
        ],
        "license": [
            "MIT",
            "BSD-3",
            "GNU GPL v3.0",
            "Apache Software License 2.0"
        ],
        "license_owner": "{{ cookiecutter.go_module_path.split('/')[1] }}",
        "project_description": "go-template creates a customized Go project template to use as a base for your next project",
        "project_name": "go-template",
        "use_codecov": "y",
        "use_precommit": "y"
    }
}
```

## Cause of the Issue

Until now, the expression used to set the default value for the `cookiecutter.license_owner` field would assume that the module name belongs to a Github repository. The default value for the field would split the module name with this assumption in mind! Here is the expression being used to populate the license owner field by default:

       {{ cookiecutter.go_module_path.split('/')[1] }}

With the previous expression, if the module path entered was not a link, and was a simple name - such as `local` - the previous logic used to split string would result in a runtime crash.

## The Patch

The module path field was being used at multiple points in the codebase. This pull request patches the issue by introducing multiple (non-breaking) changes to the flow of control:
 - Hardcode a default value for the `license_owner` field in Cookiecutter configs
 - Add a pre-gen hook to verify module path belongs to Github if Github specific features are to be included
 - Patch `dependabot.yml` to be populated only if Github specific features are enabled