### PR TITLE
Feature: Introduce build modes for direct Makefile runs

### DIFF
--- a/{{ cookiecutter.project_name.strip() }}/Makefile
+++ b/{{ cookiecutter.project_name.strip() }}/Makefile
@@ -160,5 +160,3 @@ clean-docker:
 ## :
 ## : Example;
 ## :	`make run q="time --version"`
-## : This is the same as;
-## : 	./{{ cookiecutter.project_name.strip() }} version --help

--- a/{{ cookiecutter.project_name.strip() }}/Makefile
+++ b/{{ cookiecutter.project_name.strip() }}/Makefile
@@ -109,6 +109,13 @@ run: export __BUILD_MODE__=production
 run:
 	go run main.go $(q)
 
+.PHONY: run-debug
+## `run-debug`: Run `{{ cookiecutter.project_name.strip() }}` in debug mode
+run-debug: export debug_mode=debug
+run-debug: export __BUILD_MODE__=debug
+run-debug:
+	go run main.go $(q)
+
 
 .PHONY: docker-gen
 ## :

--- a/{{ cookiecutter.project_name.strip() }}/Makefile
+++ b/{{ cookiecutter.project_name.strip() }}/Makefile
@@ -103,13 +103,15 @@ test-suite: lint test
 
 .PHONY: run
 ## :
-## `run`: Run `{{ cookiecutter.project_name.strip() }}`
-##  : Optional; `make run q="args"` to pass arguments
+## `run`: Run `{{ cookiecutter.project_name.strip() }}` in production mode
+run: export production_mode=production
+run: export __BUILD_MODE__=production
 run:
 	go run main.go $(q)
 
 
 .PHONY: docker-gen
+## :
 ## `docker-gen`: Create a production docker image for `{{ cookiecutter.project_name.strip() }}`
 docker-gen:
 	echo "Building docker image \`$(IMAGE):$(VERSION)\`..."

--- a/{{ cookiecutter.project_name.strip() }}/Makefile
+++ b/{{ cookiecutter.project_name.strip() }}/Makefile
@@ -153,4 +153,12 @@ clean-docker:
 ## : image being targeted
 ## :
 ## : Example;
-## :     `make docker-gen IMAGE=new_project VERSION=3.15`
+## :     make docker-gen IMAGE=new_project VERSION=3.15
+## :
+## : Likewise, both the `run` commands can pass runtime
+## : arguments under the `q` arg
+## :
+## : Example;
+## :	`make run q="time --version"`
+## : This is the same as;
+## : 	./{{ cookiecutter.project_name.strip() }} version --help

--- a/{{ cookiecutter.project_name.strip() }}/main.go
+++ b/{{ cookiecutter.project_name.strip() }}/main.go
@@ -44,7 +44,7 @@ func firstCheck() {
 		// Could also use a simple `else` statement (above) for docker builds!
 		fmt.Println("(Check 01): Running in `debug` mode!")
 	} else {
-		fmt.Println("\nP.S. Try running a docker build generated with the Makefile :)")
+		fmt.Println("\nP.S. Try running a build generated with the Makefile :)")
 	}
 }
 
@@ -69,6 +69,6 @@ func secondCheck() {
 
 	default:
 		// Flow ends up here for non-docker builds, or docker builds generated directly
-		fmt.Println("Unknown value detected :(")
+		fmt.Println("Non-makefile build detected :(")
 	}
 }


### PR DESCRIPTION
## Description

Similar to how the application has two build modes for docker containers - the Makefile can be used to introduce a new `debug` mode to normal runs of applications as well!

The changes made in this branch relate to creating environment variables with the `make run` and `make run-debug` commands! 

When running the default `run` command - the Makefile will create the environment variables `production_mode=production` and `__BUILD_MODE__=production`. Likewise, `run-debug` will create environment variables `debug_mode=debug` and `__BUILD_MODE__=debug`

**Note:** These values are exactly the same as introduced in #33

Applications can make use of these values to modify their behavior depending on the build mode!

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [x] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)
