### PR TITLE
Fix: Remove deprecated linters

### DIFF
--- a/{{ cookiecutter.project_name.strip() }}/.golangci.yml
+++ b/{{ cookiecutter.project_name.strip() }}/.golangci.yml
@@ -285,26 +285,6 @@ linters-settings:
     #   - shadow
     disable-all: false
 
-  depguard:
-    # linter to check if package imports are in a list of acceptable packages
-    list-type: blacklist    # either `blacklist` or `whitelist`
-    include-go-root: false
-    # packages:
-    #   - github.com/sirupsen/logrus
-
-    # specify an error message to output when a blacklisted package is used
-    # packages-with-error-message:
-      # - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
-
-  ifshort:
-    # max length of variable declaration measured in number of lines, beyond which
-    # linter won't suggest using short syntax - higher priority than `max-decl-chars`
-    max-decl-lines: 1
-
-    # max length of variable declaration measured in number of characters, beyond which
-    #  linter won't suggest using short syntax
-    max-decl-chars: 30
-
   lll:
     # max line length, lines longer will be reported. Default is 120.
     line-length: 88   # tab (`\t`) is counted as 1 character by default
@@ -466,20 +446,16 @@ linters:
   disable-all: true   # disable all, selectively enable what is needed
   enable:
     # Defaults
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
     # Additional
     - cyclop
-    - depguard
     - dogsled
     - dupl
     - errname
@@ -498,7 +474,6 @@ linters:
     - gomnd
     - goprintffuncname
     - gosec
-    - ifshort
     - lll
     - makezero
     - misspell
@@ -536,3 +511,6 @@ linters:
   # version
   #  - nilnil
   #  - tenv
+
+  # Might be useful for larger/coporate projects. Probably not for a hobby project
+  # - depguard


### PR DESCRIPTION
## Description

Few linters were marked deprecated due to lack of active development upstream, removed them from the `.golangci.yml` configuration file

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [x] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)
