### PR TITLE
Feature: Generating private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ directly for quick setup instructions ;)
 
 ## :boom: Features
 
-This is a battries-included [cookiecutter :cookie:][cookiecutter-link] template to get
+This is a batteries-included [cookiecutter :cookie:][cookiecutter-link] template to get
 you started with the essentials you'll need for your next Go project ;)
 
 ### Development
@@ -120,19 +120,20 @@ values, and what they are used for
 > These defaults **must** be filled with actual values during the setup!
 <br>
 
-| Parameter                  | Default Value           | Usage                                                                                                                                                                                          |
-|----------------------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `project_name`             | `example-project`       | Name of the project. A directory of this name will be created in the current working directory                                                                                                 |
-| `project_description`      | Based on `project_name` | A small description of the project, used to generate `GNU` license file, and default readme                                                                                                    |
-| `go_module_path`           | Based on `project_name` | Complete Go module path for the generated project, use a valid Github URL to enable Github specific features                                                                                   |
-| `license_owner`            | example                 | Used in `LICENSE` and other files. Can be the name of a person or an organization.                                                                                                             |
-| `base_branch`              | `master`                | The stable/base branch. Used for build status badges and release-drafter (if you enable Github specific features)                                                                              |
-| `contact_email`            | `""`                    | Email to get in touch with project stakeholders. `CODE_OF_CONDUCT.md` and `SECURITY.md` will be removed if empty. [Why is this needed?](#why-is-my-email-id-needed)                            |
-| `github_specific_features` | **y**                   | Yes or No (`y` or `n`). Dictates if Github-specific features should be included in the project (issue templates, pipeline, etc). [More Info](#what-does-the-github_specific_features-field-do) |
-| `use_codecov`              | **y**                   | Yes or No (`y` or `n`). Decides if [Codecov](http://codecov.com) is to be used in the project or not. Checkout [Setting up codecov](#how-to-integrate-codecov-for-automated-code-analysis)     |
-| `use_precommit`            | **y**                   | Yes or No (`y` or `n`). Decides if [*pre-commit*](https://pre-commit.com) configs should be included with the generated templates                                                              |
-| `go_version`               | `1.17`                  | The version of Go to use in the project. Can be either `1.16`, `1.17` or `1.18`                                                                                                                |
-| `license`                  | `MIT`                   | The license you want to use in the generated project. One of `MIT`, `BSD-3`, `GNU GPL v3.0` and `Apache Software License 2.0`                                                                  |
+| Parameter                  | Default Value           | Usage                                                                                                                                                                                                 |
+|----------------------------|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `project_name`             | `example-project`       | Name of the project. A directory of this name will be created in the current working directory                                                                                                        |
+| `project_description`      | Based on `project_name` | A small description of the project, used to generate `GNU` license file, and default readme                                                                                                           |
+| `go_module_path`           | Based on `project_name` | Complete Go module path for the generated project, use a valid Github URL to enable Github specific features                                                                                          |
+| `license_owner`            | example                 | Used in `LICENSE` and other files. Can be the name of a person or an organization.                                                                                                                    |
+| `base_branch`              | `master`                | The stable/base branch. Used for build status badges and release-drafter (if you enable Github specific features)                                                                                     |
+| `contact_email`            | `""`                    | Email to get in touch with project stakeholders. `CODE_OF_CONDUCT.md` and `SECURITY.md` will be removed if empty. [Why is this needed?](#why-is-my-email-id-needed)                                   |
+| `github_specific_features` | **y**                   | Yes or No (`y` or `n`). Dictates if Github-specific features should be included in the project (issue templates, pipeline, etc). [More Info](#what-does-the-github_specific_features-field-do)        |
+| `private_project`          | **n**                   | Yes or No (`y` or `n`). Inquires if the project repository generated will be publicly accessible, or private. [Why is this needed?](#why-do-i-need-to-inform-if-the-generated-project-will-be-public) |
+| `use_codecov`              | **y**                   | Yes or No (`y` or `n`). Decides if [Codecov](http://codecov.com) is to be used in the project or not. Checkout [Setting up codecov](#how-to-integrate-codecov-for-automated-code-analysis)            |
+| `use_precommit`            | **y**                   | Yes or No (`y` or `n`). Decides if [*pre-commit*](https://pre-commit.com) configs should be included with the generated templates                                                                     |
+| `go_version`               | `1.17`                  | The version of Go to use in the project. Can be either `1.16`, `1.17` or `1.18`                                                                                                                       |
+| `license`                  | `MIT`                   | The license you want to use in the generated project. One of `MIT`, `BSD-3`, `GNU GPL v3.0` and `Apache Software License 2.0`                                                                         |
 
 All values entered while setting up the Cookiecutter template will be saved in
 `cookiecutter-config-file.yml`, you can refer to them in the generated project :wink:
@@ -224,6 +225,15 @@ can use this field to ensure the generated project is free of Github-specific fi
 > **Note:** If Github specific features are required, the value of `go_module_path`
 > should be a path to a Github repository (does not matter if it exists). This would be
 > used for `dependabot.yml`
+
+#### Why do I need to inform if the generated project will be public?
+
+As of now, the only change(s) being made based on this are all restricted to the README
+file of generated projects. This is required as some badges used in the README require
+the project to be accessible by `shields.io` — the service behind these badges!
+
+For private projects, these badges will either be removed or modified, to prevent cases
+where badges break down for private repositories!
 
 #### How to integrate Codecov for automated code analysis?
 

--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ you start working (especially if you're picking up one of these tasks);
  - [ ] Add [Earthly][earthly-link]? Not sure if this is needed in the first place.
  - [ ] Customize [build-script.sh][build-script-file] to generate binaries/executables
        for selective OSes
- - [ ] Option to generate private projects - Shield badges and *<more stuff>* need the
+ - [x] ~~Option to generate private projects~~ - Shield badges and *<more stuff>* need the
        project to be public. It would be great to have an option to generate private
-       projects using *go-template*!
+       projects using *go-template*! (Accomplished via notsatan/go-template#51)
 
 ## :trophy: Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ you start working (especially if you're picking up one of these tasks);
        for selective OSes
  - [x] ~~Option to generate private projects~~ - Shield badges and *<more stuff>* need the
        project to be public. It would be great to have an option to generate private
-       projects using *go-template*! (Accomplished via notsatan/go-template#51)
+       projects using *go-template*! (Accomplished via notsatan/go-template#52)
 
 ## :trophy: Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![No Dependencies](https://img.shields.io/badge/Dependencies-None-green?style=for-the-badge&logo=dependabot)][gomod-file]
 [![MIT License](https://img.shields.io/github/license/notsatan/go-template?color=red&style=for-the-badge)][project-license]
 [![Pre-Commit Enabled](https://img.shields.io/badge/Pre--Commit-Enabled-blue?style=for-the-badge&logo=pre-commit)][project-precommit]
-[![Go v1.19+](https://img.shields.io/badge/Go-%20v1.19-black?style=for-the-badge&logo=go)][go-releases]
+[![Go v1.19+](https://img.shields.io/badge/Go-%20v1.19+-black?style=for-the-badge&logo=go)][go-releases]
 [![Makefile Included](https://img.shields.io/badge/Makefile-Supported%20🚀-red?style=for-the-badge&logo=probot)][makefile-file]
 
 A bleeding-edge Go project generator for your next project :wink:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![A gif displaying `go-template` in action][demo-gif]
 
-[![Build status](https://img.shields.io/github/workflow/status/notsatan/go-template/Black?style=for-the-badge&logo=github)][black-action]
+[![Build status](https://img.shields.io/github/actions/workflow/status/notsatan/go-template/black.yml?style=for-the-badge&logo=github)][black-action]
 [![No Dependencies](https://img.shields.io/badge/Dependencies-None-green?style=for-the-badge&logo=dependabot)][gomod-file]
 [![MIT License](https://img.shields.io/github/license/notsatan/go-template?color=red&style=for-the-badge)][project-license]
 [![Pre-Commit Enabled](https://img.shields.io/badge/Pre--Commit-Enabled-blue?style=for-the-badge&logo=pre-commit)][project-precommit]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![No Dependencies](https://img.shields.io/badge/Dependencies-None-green?style=for-the-badge&logo=dependabot)][gomod-file]
 [![MIT License](https://img.shields.io/github/license/notsatan/go-template?color=red&style=for-the-badge)][project-license]
 [![Pre-Commit Enabled](https://img.shields.io/badge/Pre--Commit-Enabled-blue?style=for-the-badge&logo=pre-commit)][project-precommit]
-[![Go v1.16+](https://img.shields.io/badge/Go-%20v1.16-black?style=for-the-badge&logo=go)][go-releases]
+[![Go v1.19+](https://img.shields.io/badge/Go-%20v1.19-black?style=for-the-badge&logo=go)][go-releases]
 [![Makefile Included](https://img.shields.io/badge/Makefile-Supported%20🚀-red?style=for-the-badge&logo=probot)][makefile-file]
 
 A bleeding-edge Go project generator for your next project :wink:
@@ -37,7 +37,7 @@ you started with the essentials you'll need for your next Go project ;)
 
 ### Development
 
- - Supports Go `v1.16`, `v1.17` and `v1.18`
+ - Supports Go `v1.19`, `v1.20` and `v1.21`
  - Automated code formatting with [gofmt][gofmt-link] and [gofumpt][gofumpt-link]
  - Sort imports with [goimports][goimports-link] and [gci][gci-link]
  - Ready to use [pre-commit][precommit-link] setup, complete with a ton of hooks

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
     "base_branch": "master",
     "contact_email": "",
     "github_specific_features": "y",
+    "private_project": "n",
     "use_codecov": "y",
     "use_precommit": "y",
     "go_version": [

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -18,7 +18,7 @@ temp_directories: List[str] = [
 ]
 
 
-def lincese_generator():
+def license_generator():
     """
     Generates the appropriate license for the template from the given options
     """
@@ -177,7 +177,7 @@ def print_final_instructions():
 
 
 runners: Callable[[Optional[Any]], None] = [
-    lincese_generator,
+    license_generator,
     create_temp_directories,
     remove_codecov,
     disable_github_features,

--- a/{{ cookiecutter.project_name.strip() }}/Makefile
+++ b/{{ cookiecutter.project_name.strip() }}/Makefile
@@ -10,10 +10,6 @@ PROJECTNAME="{{ cookiecutter.project_name.strip() }}"
 # List of all Go-files to be processed
 GOFILES=$(wildcard *.go)
 
-# Redirecting error output to a file, acts as logs that can
-# be referenced if needed
-STDERR=/tmp/$(PROJECTNAME)-stderr.txt
-
 # Docker image variables
 IMAGE := $(PROJECTNAME)
 VERSION := latest

--- a/{{ cookiecutter.project_name.strip() }}/README.md
+++ b/{{ cookiecutter.project_name.strip() }}/README.md
@@ -3,7 +3,9 @@
 {% if cookiecutter.github_specific_features.lower() == 'y' -%}
 <div align="center">
 
+{% if cookiecutter.private_project.lower() == "n" -%}
 [![Build Status](https://img.shields.io/github/checks-status/{{ cookiecutter.go_module_path.strip('/').replace('github.com/', '') }}/{{ cookiecutter.base_branch.strip() }}?color=black&style=for-the-badge&logo=github)][github-actions]
+{% endif -%}
 {% if cookiecutter.use_codecov.lower() == 'y' -%}
 [![Code Coverage](https://img.shields.io/codecov/c/{{ cookiecutter.go_module_path.strip('/').replace('.com', '') }}?color=blue&logo=codecov&style=for-the-badge)][github-actions-tests]
 {% endif -%}
@@ -11,7 +13,11 @@
 [![Dependencies Status](https://img.shields.io/badge/Dependencies-Up%20to%20Date-brightgreen?style=for-the-badge&logo=dependabot)][dependabot-pulls]
 [![Semantic Versioning](https://img.shields.io/badge/versioning-semantic-black?style=for-the-badge&logo=semver)][github-releases]
 [![Pre-Commit Enabled](https://img.shields.io/badge/Pre--Commit-Enabled-blue?style=for-the-badge&logo=pre-commit)][precommit-config]
-[![License](https://img.shields.io/github/license/{{ cookiecutter.go_module_path.strip('/').replace('github.com/', '') }}?color=red&style=for-the-badge)][project-license]
+{% if cookiecutter.private_project.lower() == "n" -%}
+[![License](https://img.shields.io/github/license/{{ cookiecutter.go_module_path.strip('/').replace('github.com/', '') }}?color=red&style=for-the-badge&logo=unlicense)][project-license]
+{% else -%}
+[![License](https://img.shields.io/badge/License-{{ cookiecutter.license.replace('-', '--').replace('Software License ', '').replace(' ', '%20') }}-lightgrey?color=red&style=for-the-badge&logo=unlicense)][project-license]
+{% endif -%}
 [![Go v{{ cookiecutter.go_version }}](https://img.shields.io/badge/Go-%20v{{ cookiecutter.go_version }}-black?style=for-the-badge&logo=go)][gomod-file]
 
 {{ cookiecutter.project_description }}

--- a/{{ cookiecutter.project_name.strip() }}/cookiecutter-config-file.yml
+++ b/{{ cookiecutter.project_name.strip() }}/cookiecutter-config-file.yml
@@ -9,6 +9,7 @@ cookiecutter_inputs:
   contact_email: "{{ cookiecutter.contact_email }}"
   project_description: "{{ cookiecutter.project_description }}"
   github_specific_features: "{{ cookiecutter.github_specific_features }}"
+  private_project: "{{ cookiecutter.private_project }}"
   use_codecov: "{{ cookiecutter.use_codecov }}"
   use_precommit: "{{ cookiecutter.use_precommit }}"
   go_version: "{{ cookiecutter.go_version }}"


### PR DESCRIPTION
## Description

Up until now, projects were generated by `go-template` under the assumption that they will always be public — which, isn't always true. Private projects would end up with broken links on their README because `shields.io` can't access the project!

This feature intends to resolve this by removing/updating the links on the generated README to ensure private repositories can generate a project with this template and use it right out of box

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [x] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)
