### PR TITLE
Fix: Patch regex pattern for Github validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 .vscode/
 venv/
+
+.DS_Store/**

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -11,7 +11,7 @@ def is_module_hosted_on_github():
     """
 
     # Regex pattern to validate module name - might need some tweaks
-    pattern = r"^github.com\/[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-]+\/?$"
+    pattern = r"^github.com\/[\w\-]+\/[\w\-]+\/?$"
 
     # If the user has not opted for Github-specific features, skip
     perform_check: bool = bool(

--- a/{{ cookiecutter.project_name.strip() }}/.gitignore
+++ b/{{ cookiecutter.project_name.strip() }}/.gitignore
@@ -2,6 +2,9 @@
 .vscode/**
 .idea/**
 
+# Mac only
+.DS_Store/**
+
 # Ignore directories containing binaries generated and other stuff
 tmp/**
 bin/**


### PR DESCRIPTION
## Description

Apparently, the regex pattern being used to validate if a module-path was a Github repository did not allow for underscores in the user/repository name

https://github.com/notsatan/go-template/blob/e146f9e1dd6951a53cfb1306897df407b354852a/hooks/pre_gen_project.py#L13-L14

This PR closes #53

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [x] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)
